### PR TITLE
Fixed reset() to prevent pageCount out-of-bounds

### DIFF
--- a/hudebug.lua
+++ b/hudebug.lua
@@ -102,6 +102,8 @@ end
 function hudebug.reset()
     hudebug.slots = nil
     hudebug.slots = {}
+    hudebug.pageCount = 0
+    hudebug.page = 1
     if hudebug.active then
       hudebug.active = false
     end


### PR DESCRIPTION
Using reset() failed to update pageCount leading to out of bounds access to pages.